### PR TITLE
Use Monitor mock in tests instead of ConsoleMonitor

### DIFF
--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtensionTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtensionTest.java
@@ -27,7 +27,6 @@ import org.eclipse.dataspaceconnector.identityhub.client.IdentityHubClient;
 import org.eclipse.dataspaceconnector.identityhub.client.IdentityHubClientImpl;
 import org.eclipse.dataspaceconnector.junit.extensions.EdcExtension;
 import org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils;
-import org.eclipse.dataspaceconnector.spi.monitor.ConsoleMonitor;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,7 +57,7 @@ public class CredentialsVerifierExtensionTest {
 
     @BeforeEach
     void setUp(EdcExtension extension) {
-        identityHubClient = new IdentityHubClientImpl(TestUtils.testOkHttpClient(), new ObjectMapper(), new ConsoleMonitor());
+        identityHubClient = new IdentityHubClientImpl(TestUtils.testOkHttpClient(), new ObjectMapper(), mock(Monitor.class));
         extension.registerServiceMock(Monitor.class, mock(Monitor.class));
         extension.setConfiguration(Map.of("web.http.port", String.valueOf(PORT)));
     }

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifierTest.java
@@ -20,7 +20,6 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil;
-import org.eclipse.dataspaceconnector.spi.monitor.ConsoleMonitor;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.junit.jupiter.api.Test;
@@ -41,7 +40,6 @@ import static org.mockito.Mockito.when;
 public class DidJwtCredentialsVerifierTest {
 
     private static final Faker FAKER = new Faker();
-    private static final Monitor MONITOR = new ConsoleMonitor();
     private static final ECKey JWK = generateEcKey();
     private static final ECKey ANOTHER_JWK = generateEcKey();
     private static final String ISSUER = FAKER.internet().url();
@@ -49,7 +47,7 @@ public class DidJwtCredentialsVerifierTest {
     private static final String OTHER_SUBJECT = FAKER.internet().url() + "other";
     private static final SignedJWT JWT = buildSignedJwt(generateVerifiableCredential(), ISSUER, SUBJECT, JWK);
     private DidPublicKeyResolver didPublicKeyResolver = mock(DidPublicKeyResolver.class);
-    private DidJwtCredentialsVerifier didJwtCredentialsVerifier = new DidJwtCredentialsVerifier(didPublicKeyResolver, MONITOR);
+    private DidJwtCredentialsVerifier didJwtCredentialsVerifier = new DidJwtCredentialsVerifier(didPublicKeyResolver, mock(Monitor.class));
 
     @Test
     public void isSignedByIssuer_jwtSignedByIssuer() {

--- a/identity-hub-core/identity-hub-client/build.gradle.kts
+++ b/identity-hub-core/identity-hub-client/build.gradle.kts
@@ -25,6 +25,7 @@ val jupiterVersion: String by project
 val faker: String by project
 val assertj: String by project
 val nimbusVersion: String by project
+val mockitoVersion: String by project
 
 dependencies {
     api(project(":spi:identity-hub-spi"))
@@ -44,6 +45,7 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation("com.github.javafaker:javafaker:${faker}")
+    testImplementation("org.mockito:mockito-core:${mockitoVersion}")
 }
 
 publishing {

--- a/identity-hub-core/identity-hub-client/src/test/java/org/eclipse/dataspaceconnector/identityhub/client/IdentityHubClientImplIntegrationTest.java
+++ b/identity-hub-core/identity-hub-client/src/test/java/org/eclipse/dataspaceconnector/identityhub/client/IdentityHubClientImplIntegrationTest.java
@@ -20,7 +20,7 @@ import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.dataspaceconnector.identityhub.credentials.model.VerifiableCredential;
 import org.eclipse.dataspaceconnector.junit.extensions.EdcExtension;
 import org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils;
-import org.eclipse.dataspaceconnector.spi.monitor.ConsoleMonitor;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,6 +30,7 @@ import java.io.IOException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.buildSignedJwt;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.generateEcKey;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(EdcExtension.class)
 public class IdentityHubClientImplIntegrationTest {
@@ -43,7 +44,7 @@ public class IdentityHubClientImplIntegrationTest {
     @BeforeEach
     void setUp() {
         var okHttpClient = TestUtils.testOkHttpClient();
-        client = new IdentityHubClientImpl(okHttpClient, OBJECT_MAPPER, new ConsoleMonitor());
+        client = new IdentityHubClientImpl(okHttpClient, OBJECT_MAPPER, mock(Monitor.class));
     }
 
     @Test

--- a/identity-hub-core/identity-hub-client/src/test/java/org/eclipse/dataspaceconnector/identityhub/client/IdentityHubClientImplTest.java
+++ b/identity-hub-core/identity-hub-client/src/test/java/org/eclipse/dataspaceconnector/identityhub/client/IdentityHubClientImplTest.java
@@ -27,7 +27,7 @@ import org.eclipse.dataspaceconnector.identityhub.model.MessageResponseObject;
 import org.eclipse.dataspaceconnector.identityhub.model.MessageStatus;
 import org.eclipse.dataspaceconnector.identityhub.model.RequestStatus;
 import org.eclipse.dataspaceconnector.identityhub.model.ResponseObject;
-import org.eclipse.dataspaceconnector.spi.monitor.ConsoleMonitor;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
 import org.junit.jupiter.api.Test;
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.buildSignedJwt;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.generateEcKey;
 import static org.eclipse.dataspaceconnector.identityhub.model.MessageResponseObject.MESSAGE_ID_VALUE;
+import static org.mockito.Mockito.mock;
 
 public class IdentityHubClientImplTest {
     private static final Faker FAKER = new Faker();
@@ -171,6 +172,6 @@ public class IdentityHubClientImplTest {
                 .addInterceptor(interceptor)
                 .build();
 
-        return new IdentityHubClientImpl(okHttpClient, OBJECT_MAPPER, new ConsoleMonitor());
+        return new IdentityHubClientImpl(okHttpClient, OBJECT_MAPPER, mock(Monitor.class));
     }
 }


### PR DESCRIPTION
## What this PR changes/adds

In tests we use ConsoleMonitor and Monitor mock.
The PR make it consistent by using Monitor mock in every tests.

## Why it does that

For consistency and have a clean test output console.

## Linked Issue(s)

No issue, it is just a quick cleanup for consistency.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/styleguide.md) for details_)
