### PR TITLE
IdentityHubCredentialsVerifier fails if credential is invalid

### DIFF
--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
@@ -94,7 +94,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
         var claims = extractClaimsFromCredential(verifiedCredentials);
 
         if (claims.failed()) {
-            monitor.warning("Credentials verification failed");
+            monitor.severe(String.format("Credentials verification failed: %s", claims.getFailureDetail()));
             return Result.failure(claims.getFailureDetail());
         } else {
             return Result.success(claims.getContent());

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
@@ -146,7 +146,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
 
     private static class VerificationResult extends AbstractResult<Map<String, Object>, Failure> {
         VerificationResult(Map<String, Object> succeededCredentials, List<String> failureMessage) {
-            super(succeededCredentials, new Failure(failureMessage));
+            super(succeededCredentials, failureMessage.isEmpty() ? null : new Failure(failureMessage));
         }
     }
 }

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
@@ -123,7 +123,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
                 .map(verifiableCredentialsJwtService::extractCredential)
                 .collect(partitioningBy(AbstractResult::succeeded));
 
-        var successful = result.get(true).stream()
+        var successfulResults = result.get(true).stream()
                 .map(AbstractResult::getContent)
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
@@ -131,7 +131,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
                 .map(AbstractResult::getFailureDetail)
                 .collect(Collectors.toList());
 
-        return new VerificationResult(successful, failedResults);
+        return new VerificationResult(successfulResults, failedResults);
     }
 
     private String getIdentityHubBaseUrl(DidDocument didDocument) {

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
@@ -94,7 +94,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
         var claims = extractClaimsFromCredential(verifiedCredentials);
 
         if (claims.failed()) {
-            monitor.severe(String.format("Credentials verification failed: %s", claims.getFailureDetail()));
+            monitor.severe(() -> String.format("Credentials verification failed: %s", claims.getFailureDetail()));
             return Result.failure(claims.getFailureDetail());
         } else {
             return Result.success(claims.getContent());

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
@@ -37,7 +37,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.buildSignedJwt;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.generateEcKey;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.generateVerifiableCredential;
-import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.toMap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -62,7 +61,7 @@ public class IdentityHubCredentialsVerifierTest {
     private CredentialsVerifier credentialsVerifier = new IdentityHubCredentialsVerifier(identityHubClientMock, monitorMock, jwtCredentialsVerifierMock, verifiableCredentialsJwtService);
 
     @Test
-    public void getVerifiedClaims_getValidClaims() throws Exception {
+    public void getVerifiedClaims_getValidClaims() {
 
         // Arrange
         var credential = generateVerifiableCredential();
@@ -73,10 +72,7 @@ public class IdentityHubCredentialsVerifierTest {
         var credentials = credentialsVerifier.getVerifiedCredentials(DID_DOCUMENT);
 
         // Assert
-        assertThat(credentials.succeeded()).isTrue();
-        assertThat(credentials.getContent())
-                .usingRecursiveComparison()
-                .isEqualTo(toMap(credential, ISSUER, SUBJECT));
+        assertThat(credentials.failed()).isTrue();
     }
 
     private void setUpMocks(SignedJWT jws, boolean isSigned, boolean claimsValid) {
@@ -86,7 +82,7 @@ public class IdentityHubCredentialsVerifierTest {
     }
 
     @Test
-    public void getVerifiedClaims_filtersSignedByWrongIssuer() throws Exception {
+    public void getVerifiedClaims_filtersSignedByWrongIssuer() {
 
         // Arrange
         var credential = generateVerifiableCredential();
@@ -97,8 +93,7 @@ public class IdentityHubCredentialsVerifierTest {
         var credentials = credentialsVerifier.getVerifiedCredentials(DID_DOCUMENT);
 
         // Assert
-        assertThat(credentials.succeeded()).isTrue();
-        assertThat(credentials.getContent().size()).isEqualTo(0);
+        assertThat(credentials.failed()).isTrue();
     }
 
     @Test
@@ -138,8 +133,7 @@ public class IdentityHubCredentialsVerifierTest {
         var credentials = credentialsVerifier.getVerifiedCredentials(DID_DOCUMENT);
 
         // Assert
-        assertThat(credentials.succeeded()).isTrue();
-        assertThat(credentials.getContent().isEmpty());
+        assertThat(credentials.failed()).isTrue();
         verify(monitorMock, times(1)).warning(anyString());
 
     }
@@ -161,8 +155,7 @@ public class IdentityHubCredentialsVerifierTest {
         var credentials = credentialsVerifier.getVerifiedCredentials(DID_DOCUMENT);
 
         // Assert
-        assertThat(credentials.succeeded()).isTrue();
-        assertThat(credentials.getContent().isEmpty());
+        assertThat(credentials.failed()).isTrue();
         verify(monitorMock, times(1)).warning(anyString());
     }
 

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
@@ -29,9 +29,11 @@ import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.buildSignedJwt;
@@ -39,7 +41,6 @@ import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.Veri
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.generateVerifiableCredential;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.toMap;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -139,8 +140,7 @@ public class IdentityHubCredentialsVerifierTest {
 
         // Assert
         assertThat(credentials.failed()).isTrue();
-        verify(monitorMock, times(1)).severe(anyString());
-
+        verify(monitorMock, times(1)).severe(ArgumentMatchers.<Supplier<String>>any());
     }
 
     @Test
@@ -161,7 +161,7 @@ public class IdentityHubCredentialsVerifierTest {
 
         // Assert
         assertThat(credentials.failed()).isTrue();
-        verify(monitorMock, times(1)).severe(anyString());
+        verify(monitorMock, times(1)).severe(ArgumentMatchers.<Supplier<String>>any());
     }
 
 }

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
@@ -134,7 +134,7 @@ public class IdentityHubCredentialsVerifierTest {
 
         // Assert
         assertThat(credentials.failed()).isTrue();
-        verify(monitorMock, times(1)).warning(anyString());
+        verify(monitorMock, times(1)).severe(anyString());
 
     }
 
@@ -156,7 +156,7 @@ public class IdentityHubCredentialsVerifierTest {
 
         // Assert
         assertThat(credentials.failed()).isTrue();
-        verify(monitorMock, times(1)).warning(anyString());
+        verify(monitorMock, times(1)).severe(anyString());
     }
 
 }

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.buildSignedJwt;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.generateEcKey;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.generateVerifiableCredential;
+import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.toMap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -73,6 +74,9 @@ public class IdentityHubCredentialsVerifierTest {
 
         // Assert
         assertThat(credentials.succeeded()).isTrue();
+        assertThat(credentials.getContent())
+                .usingRecursiveComparison()
+                .isEqualTo(toMap(credential, ISSUER, SUBJECT));
     }
 
     private void setUpMocks(SignedJWT jws, boolean isSigned, boolean claimsValid) {

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
@@ -72,7 +72,7 @@ public class IdentityHubCredentialsVerifierTest {
         var credentials = credentialsVerifier.getVerifiedCredentials(DID_DOCUMENT);
 
         // Assert
-        assertThat(credentials.failed()).isTrue();
+        assertThat(credentials.succeeded()).isTrue();
     }
 
     private void setUpMocks(SignedJWT jws, boolean isSigned, boolean claimsValid) {
@@ -93,7 +93,8 @@ public class IdentityHubCredentialsVerifierTest {
         var credentials = credentialsVerifier.getVerifiedCredentials(DID_DOCUMENT);
 
         // Assert
-        assertThat(credentials.failed()).isTrue();
+        assertThat(credentials.succeeded()).isTrue();
+        assertThat(credentials.getContent().size()).isEqualTo(0);
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Changed the logic of the IdentityhubCredentialsVerifier to fail if one credential has an invalid format.
The long term goal is that the CredentialsVerifier returns Failures and success and give the choice to the client to succeed or fail.

Next steps: Will do a second PR on the same feature branch to fail if one credential has invalid signature or signature can't be verified.

## Linked Issue(s)

https://github.com/agera-edc/IdentityHub/issues/47

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/styleguide.md) for details_)
