### PR TITLE
IdentityHubCredentialsVerifier: Fails if one VC signature verification fails

### DIFF
--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/AggregatedResult.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/AggregatedResult.java
@@ -28,8 +28,8 @@ import java.util.List;
  *
  * @param <T> Result type
  */
-class VerificationResult<T> extends AbstractResult<T, Failure> {
-    VerificationResult(T successfulResult, List<String> failureMessage) {
+class AggregatedResult<T> extends AbstractResult<T, Failure> {
+    AggregatedResult(T successfulResult, List<String> failureMessage) {
         super(successfulResult, failureMessage.isEmpty() ? null : new Failure(failureMessage));
     }
 }

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifier.java
@@ -48,15 +48,11 @@ class DidJwtCredentialsVerifier implements JwtCredentialsVerifier {
         try {
             issuer = jwt.getJWTClaimsSet().getIssuer();
         } catch (ParseException e) {
-            var failureMessage = "Error parsing issuer from JWT";
-            monitor.warning(failureMessage, e);
-            return Result.failure(String.format("%s: %s", failureMessage, e.getMessage()));
+            return Result.failure(String.format("Error parsing issuer from JWT: %s", e.getMessage()));
         }
         var issuerPublicKey = didPublicKeyResolver.resolvePublicKey(issuer);
         if (issuerPublicKey.failed()) {
-            var failureMessage = String.format("Failed finding publicKey of issuer: %s", issuer);
-            monitor.warning(failureMessage);
-            return Result.failure(failureMessage);
+            return Result.failure(String.format("Failed finding publicKey of issuer: %s", issuer));
         }
         return verifySignature(jwt, issuerPublicKey.getContent());
     }
@@ -66,9 +62,7 @@ class DidJwtCredentialsVerifier implements JwtCredentialsVerifier {
         try {
             jwtClaimsSet = jwt.getJWTClaimsSet();
         } catch (ParseException e) {
-            var failureMessage = "Error parsing issuer from JWT";
-            monitor.warning(failureMessage, e);
-            return Result.failure(String.format("%s: %s", failureMessage, e.getMessage()));
+            return Result.failure(String.format("Error parsing issuer from JWT: %s", e.getMessage()));
         }
 
         // verify claims
@@ -82,9 +76,7 @@ class DidJwtCredentialsVerifier implements JwtCredentialsVerifier {
         try {
             claimsVerifier.verify(jwtClaimsSet);
         } catch (BadJWTException e) {
-            var failureMessage = "Failure verifying JWT token";
-            monitor.warning(failureMessage, e);
-            return Result.failure(String.format("%s: %s", failureMessage, e.getMessage()));
+            return Result.failure(String.format("Failure verifying JWT token: %s", e.getMessage()));
         }
 
         monitor.debug(() -> "JWT claims verification successful");

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifier.java
@@ -48,13 +48,15 @@ class DidJwtCredentialsVerifier implements JwtCredentialsVerifier {
         try {
             issuer = jwt.getJWTClaimsSet().getIssuer();
         } catch (ParseException e) {
-            monitor.warning("Error parsing issuer from JWT", e);
-            return Result.failure(String.format("Error parsing issuer from JWT: %s", e.getMessage()));
+            var failureMessage = "Error parsing issuer from JWT";
+            monitor.warning(failureMessage, e);
+            return Result.failure(String.format("%s: %s", failureMessage, e.getMessage()));
         }
         var issuerPublicKey = didPublicKeyResolver.resolvePublicKey(issuer);
         if (issuerPublicKey.failed()) {
-            monitor.warning(String.format("Failed finding publicKey of issuer: %s", issuer));
-            return Result.failure(String.format("Failed finding publicKey of issuer: %s", issuer));
+            var failureMessage = String.format("Failed finding publicKey of issuer: %s", issuer);
+            monitor.warning(failureMessage);
+            return Result.failure(failureMessage);
         }
         return verifySignature(jwt, issuerPublicKey.getContent());
     }
@@ -64,8 +66,9 @@ class DidJwtCredentialsVerifier implements JwtCredentialsVerifier {
         try {
             jwtClaimsSet = jwt.getJWTClaimsSet();
         } catch (ParseException e) {
-            monitor.warning("Error parsing issuer from JWT", e);
-            return Result.failure(String.format("Error parsing issuer from JWT: %s", e.getMessage()));
+            var failureMessage = "Error parsing issuer from JWT";
+            monitor.warning(failureMessage, e);
+            return Result.failure(String.format("%s: %s", failureMessage, e.getMessage()));
         }
 
         // verify claims
@@ -79,8 +82,9 @@ class DidJwtCredentialsVerifier implements JwtCredentialsVerifier {
         try {
             claimsVerifier.verify(jwtClaimsSet);
         } catch (BadJWTException e) {
-            monitor.warning("Failure verifying JWT token", e);
-            return Result.failure(String.format("Failure verifying JWT token: %s", e.getMessage()));
+            var failureMessage = "Failure verifying JWT token";
+            monitor.warning(failureMessage, e);
+            return Result.failure(String.format("%s: %s", failureMessage, e.getMessage()));
         }
 
         monitor.debug(() -> "JWT claims verification successful");
@@ -96,8 +100,9 @@ class DidJwtCredentialsVerifier implements JwtCredentialsVerifier {
             monitor.debug(() -> "JWT signature verification successful");
             return Result.success();
         } catch (JOSEException e) {
-            monitor.warning("Unable to verify JWT token", e);
-            return Result.failure("Unable to verify JWT token. " + e.getMessage());
+            var failureMessage = "Unable to verify JWT token.";
+            monitor.warning(failureMessage, e);
+            return Result.failure(String.format("%s: %s", failureMessage, e.getMessage()));
         }
     }
 }

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifier.java
@@ -48,11 +48,15 @@ class DidJwtCredentialsVerifier implements JwtCredentialsVerifier {
         try {
             issuer = jwt.getJWTClaimsSet().getIssuer();
         } catch (ParseException e) {
-            return Result.failure(String.format("Error parsing issuer from JWT: %s", e.getMessage()));
+            var failureMessage = "Error parsing issuer from JWT";
+            monitor.warning(failureMessage, e);
+            return Result.failure(String.format("%s: %s", failureMessage, e.getMessage()));
         }
         var issuerPublicKey = didPublicKeyResolver.resolvePublicKey(issuer);
         if (issuerPublicKey.failed()) {
-            return Result.failure(String.format("Failed finding publicKey of issuer: %s", issuer));
+            var failureMessage = String.format("Failed finding publicKey of issuer: %s", issuer);
+            monitor.warning(failureMessage);
+            return Result.failure(failureMessage);
         }
         return verifySignature(jwt, issuerPublicKey.getContent());
     }
@@ -62,7 +66,9 @@ class DidJwtCredentialsVerifier implements JwtCredentialsVerifier {
         try {
             jwtClaimsSet = jwt.getJWTClaimsSet();
         } catch (ParseException e) {
-            return Result.failure(String.format("Error parsing issuer from JWT: %s", e.getMessage()));
+            var failureMessage = "Error parsing issuer from JWT";
+            monitor.warning(failureMessage, e);
+            return Result.failure(String.format("%s: %s", failureMessage, e.getMessage()));
         }
 
         // verify claims
@@ -76,7 +82,9 @@ class DidJwtCredentialsVerifier implements JwtCredentialsVerifier {
         try {
             claimsVerifier.verify(jwtClaimsSet);
         } catch (BadJWTException e) {
-            return Result.failure(String.format("Failure verifying JWT token: %s", e.getMessage()));
+            var failureMessage = "Failure verifying JWT token";
+            monitor.warning(failureMessage, e);
+            return Result.failure(String.format("%s: %s", failureMessage, e.getMessage()));
         }
 
         monitor.debug(() -> "JWT claims verification successful");

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifier.java
@@ -100,7 +100,7 @@ class DidJwtCredentialsVerifier implements JwtCredentialsVerifier {
             monitor.debug(() -> "JWT signature verification successful");
             return Result.success();
         } catch (JOSEException e) {
-            var failureMessage = "Unable to verify JWT token.";
+            var failureMessage = "Unable to verify JWT token";
             monitor.warning(failureMessage, e);
             return Result.failure(String.format("%s: %s", failureMessage, e.getMessage()));
         }

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
@@ -113,7 +113,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
         var result = new AggregatedResult<>(claims.getContent(), failureMessages);
 
         // Fail if one verifiable credential is not valid. This is a temporary solution util the CredentialsVerifier
-        // contract is changed to support a result containing both successes results and failures.
+        // contract is changed to support a result containing both successful results and failures.
         if (result.failed()) {
             monitor.severe(() -> String.format("Credentials verification failed: %s", claims.getFailureDetail()));
             return Result.failure(result.getFailureDetail());

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
@@ -94,7 +94,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
         var claims = extractClaimsFromCredential(verifiedCredentials);
 
         if (claims.failed()) {
-            monitor.warning("Credentials verification failed");
+            monitor.severe(String.format("Credentials verification failed: %s", claims.getFailureDetail()));
             return Result.failure(claims.getFailureDetail());
         } else {
             return Result.success(claims.getContent());

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
@@ -123,7 +123,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
 
     @NotNull
     private VerificationResult<List<SignedJWT>> verifyCredentials(StatusResult<Collection<SignedJWT>> jwts, DidDocument didDocument) {
-        // Get credentials having the required JWT claims and are signed by the right issuer.
+        // Get valid credentials.
         var verifiedJwts = jwts.getContent()
                 .stream()
                 .map(jwt -> verifyJwtClaims(jwt, didDocument))
@@ -139,7 +139,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
                 .map(AbstractResult::getContent)
                 .collect(Collectors.toList());
 
-        // Gather failure messages.
+        // Gather failure messages of invalid credentials.
         var verificationFailures = verifiedJwts
                 .get(false)
                 .stream()

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
@@ -111,7 +111,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
         var failureMessages = Stream.concat(verifiedCredentials.getFailureMessages().stream(),
                 claims.getFailureMessages().stream()).collect(Collectors.toList());
 
-        var result = new VerificationResult<>(claims.getContent(), failureMessages);
+        var result = new AggregatedResult<>(claims.getContent(), failureMessages);
 
         // Fail if one verifiable credential is not valid. This is a temporary solution util the CredentialsVerifier
         // contract is changed to support a result containing both successes results and failures.
@@ -124,7 +124,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
     }
 
     @NotNull
-    private VerificationResult<List<SignedJWT>> verifyCredentials(StatusResult<Collection<SignedJWT>> jwts, DidDocument didDocument) {
+    private AggregatedResult<List<SignedJWT>> verifyCredentials(StatusResult<Collection<SignedJWT>> jwts, DidDocument didDocument) {
         // Get valid credentials.
         var verifiedJwts = jwts.getContent()
                 .stream()
@@ -160,7 +160,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
             monitor.warning(String.format("Found %s invalid verifiable credentials", failedResults.size()));
         }
 
-        return new VerificationResult<>(validCredentials, failedResults);
+        return new AggregatedResult<>(validCredentials, failedResults);
     }
 
     @NotNull
@@ -176,7 +176,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
     }
 
     @NotNull
-    private VerificationResult<Map<String, Object>> extractClaimsFromCredential(List<SignedJWT> verifiedCredentials) {
+    private AggregatedResult<Map<String, Object>> extractClaimsFromCredential(List<SignedJWT> verifiedCredentials) {
         var result = verifiedCredentials.stream()
                 .map(verifiableCredentialsJwtService::extractCredential)
                 .collect(partitioningBy(AbstractResult::succeeded));
@@ -189,7 +189,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
                 .map(AbstractResult::getFailureDetail)
                 .collect(Collectors.toList());
 
-        return new VerificationResult<>(successfulResults, failedResults);
+        return new AggregatedResult<>(successfulResults, failedResults);
     }
 
     private String getIdentityHubBaseUrl(DidDocument didDocument) {

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
@@ -146,7 +146,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
 
     private static class VerificationResult extends AbstractResult<Map<String, Object>, Failure> {
         VerificationResult(Map<String, Object> succeededCredentials, List<String> failureMessage) {
-            super(succeededCredentials, new Failure(failureMessage));
+            super(succeededCredentials, failureMessage.isEmpty() ? null : new Failure(failureMessage));
         }
     }
 }

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
@@ -113,6 +113,8 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
 
         var result = new VerificationResult<>(claims.getContent(), failureMessages);
 
+        // Fail if one verifiable credential is not valid. This is a temporary solution util the CredentialsVerifier
+        // contract is changed to support a result containing both successes results and failures.
         if (result.failed()) {
             monitor.severe(() -> String.format("Credentials verification failed: %s", claims.getFailureDetail()));
             return Result.failure(result.getFailureDetail());

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
@@ -108,8 +108,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
 
         var claims = extractClaimsFromCredential(verifiedCredentials.getContent());
 
-        var failureMessages = Stream.concat(verifiedCredentials.getFailureMessages().stream(),
-                claims.getFailureMessages().stream()).collect(Collectors.toList());
+        var failureMessages = mergeFailureMessages(verifiedCredentials.getFailureMessages(), claims.getFailureMessages());
 
         var result = new AggregatedResult<>(claims.getContent(), failureMessages);
 
@@ -121,6 +120,11 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
         } else {
             return Result.success(result.getContent());
         }
+    }
+
+    @NotNull
+    private List<String> mergeFailureMessages(Collection<String> messages, Collection<String> otherMessages) {
+        return Stream.concat(messages.stream(), otherMessages.stream()).collect(Collectors.toList());
     }
 
     @NotNull

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
@@ -123,7 +123,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
                 .map(verifiableCredentialsJwtService::extractCredential)
                 .collect(partitioningBy(AbstractResult::succeeded));
 
-        var successful = result.get(true).stream()
+        var successfulResults = result.get(true).stream()
                 .map(AbstractResult::getContent)
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
@@ -131,7 +131,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
                 .map(AbstractResult::getFailureDetail)
                 .collect(Collectors.toList());
 
-        return new VerificationResult(successful, failedResults);
+        return new VerificationResult(successfulResults, failedResults);
     }
 
     private String getIdentityHubBaseUrl(DidDocument didDocument) {

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
@@ -112,7 +112,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
 
         var result = new AggregatedResult<>(claims.getContent(), failureMessages);
 
-        // Fail if one verifiable credential is not valid. This is a temporary solution util the CredentialsVerifier
+        // Fail if one verifiable credential is not valid. This is a temporary solution until the CredentialsVerifier
         // contract is changed to support a result containing both successful results and failures.
         if (result.failed()) {
             monitor.severe(() -> String.format("Credentials verification failed: %s", claims.getFailureDetail()));

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
@@ -94,7 +94,7 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
         var claims = extractClaimsFromCredential(verifiedCredentials);
 
         if (claims.failed()) {
-            monitor.severe(String.format("Credentials verification failed: %s", claims.getFailureDetail()));
+            monitor.severe(() -> String.format("Credentials verification failed: %s", claims.getFailureDetail()));
             return Result.failure(claims.getFailureDetail());
         } else {
             return Result.success(claims.getContent());

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/JwtCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/JwtCredentialsVerifier.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.identityhub.verifier;
 
 import com.nimbusds.jwt.SignedJWT;
+import org.eclipse.dataspaceconnector.spi.result.Result;
 
 /**
  * Verifies verifiable credentials in JWT format.
@@ -27,7 +28,7 @@ public interface JwtCredentialsVerifier {
      * @param jwt to be verified.
      * @return if the JWT is signed by the claimed issuer.
      */
-    boolean isSignedByIssuer(SignedJWT jwt);
+    Result<Void> isSignedByIssuer(SignedJWT jwt);
 
     /**
      * Verifies if a JWT targets the given subject, and checks for the presence of the issuer ("iss") claim. The expiration ("exp") and not-before ("nbf") claims are verified if present as well.
@@ -36,5 +37,5 @@ public interface JwtCredentialsVerifier {
      * @param expectedSubject subject claim to verify.
      * @return if the JWT is valid and for the given subject
      */
-    boolean verifyClaims(SignedJWT jwt, String expectedSubject);
+    Result<Void> verifyClaims(SignedJWT jwt, String expectedSubject);
 }

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/VerificationResult.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/VerificationResult.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.identityhub.verifier;
+
+import org.eclipse.dataspaceconnector.spi.result.AbstractResult;
+import org.eclipse.dataspaceconnector.spi.result.Failure;
+
+import java.util.List;
+
+//TODO: Add javadoc.
+class VerificationResult<T> extends AbstractResult<T, Failure> {
+    VerificationResult(T successfulResult, List<String> failureMessage) {
+        super(successfulResult, failureMessage.isEmpty() ? null : new Failure(failureMessage));
+    }
+}

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/VerificationResult.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/VerificationResult.java
@@ -19,7 +19,15 @@ import org.eclipse.dataspaceconnector.spi.result.Failure;
 
 import java.util.List;
 
-//TODO: Add javadoc.
+/**
+ * A generic result type containing the result of processing plus the failures happening during the processing of the
+ * result.
+ * For example, when processing a List of objects, the processing can be successful for some objects, and unsuccessful
+ * for others.
+ * Using this class as a return type would let the client decide how to act about the failures.
+ *
+ * @param <T> Result type
+ */
 class VerificationResult<T> extends AbstractResult<T, Failure> {
     VerificationResult(T successfulResult, List<String> failureMessage) {
         super(successfulResult, failureMessage.isEmpty() ? null : new Failure(failureMessage));

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifierTest.java
@@ -194,7 +194,9 @@ public class DidJwtCredentialsVerifierTest {
         // Arrange
         var jwt = spy(JWT);
         when(didPublicKeyResolver.resolvePublicKey(ISSUER)).thenReturn(Result.success(toPublicKeyWrapper(JWK)));
-        doThrow(new JOSEException("")).when(jwt).verify(any());
+        // JOSEException can occur if JWS algorithm is not supported, or if signature verification failed for some
+        // other internal reason
+        doThrow(new JOSEException("JWS algorithm is not supported")).when(jwt).verify(any());
 
         // Act & Assert
         assertThat(didJwtCredentialsVerifier.isSignedByIssuer(jwt).failed()).isTrue();

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifierTest.java
@@ -58,7 +58,7 @@ public class DidJwtCredentialsVerifierTest {
         when(didPublicKeyResolver.resolvePublicKey(ISSUER)).thenReturn(Result.success(toPublicKeyWrapper(JWK)));
 
         // Assert
-        assertThat(didJwtCredentialsVerifier.isSignedByIssuer(JWT)).isTrue();
+        assertThat(didJwtCredentialsVerifier.isSignedByIssuer(JWT).succeeded()).isTrue();
     }
 
     @Test
@@ -68,7 +68,7 @@ public class DidJwtCredentialsVerifierTest {
         when(didPublicKeyResolver.resolvePublicKey(ISSUER)).thenReturn(Result.success(toPublicKeyWrapper(ANOTHER_JWK)));
 
         // Assert
-        assertThat(didJwtCredentialsVerifier.isSignedByIssuer(JWT)).isFalse();
+        assertThat(didJwtCredentialsVerifier.isSignedByIssuer(JWT).failed()).isTrue();
     }
 
     @Test
@@ -78,7 +78,7 @@ public class DidJwtCredentialsVerifierTest {
         when(didPublicKeyResolver.resolvePublicKey(ISSUER)).thenReturn(Result.failure("Failed resolving public key"));
 
         // Assert
-        assertThat(didJwtCredentialsVerifier.isSignedByIssuer(JWT)).isFalse();
+        assertThat(didJwtCredentialsVerifier.isSignedByIssuer(JWT).failed()).isTrue();
     }
 
     @Test
@@ -88,7 +88,7 @@ public class DidJwtCredentialsVerifierTest {
         when(didPublicKeyResolver.resolvePublicKey(JWT.getJWTClaimsSet().getIssuer())).thenReturn(Result.failure(FAKER.lorem().sentence()));
 
         // Assert
-        assertThat(didJwtCredentialsVerifier.isSignedByIssuer(JWT)).isFalse();
+        assertThat(didJwtCredentialsVerifier.isSignedByIssuer(JWT).failed()).isTrue();
     }
 
     @Test
@@ -99,29 +99,29 @@ public class DidJwtCredentialsVerifierTest {
         when(jws.getJWTClaimsSet()).thenThrow(new ParseException("Failed parsing JWT payload", 0));
 
         // Assert
-        assertThat(didJwtCredentialsVerifier.isSignedByIssuer(jws)).isFalse();
+        assertThat(didJwtCredentialsVerifier.isSignedByIssuer(jws).failed()).isTrue();
     }
 
     @Test
     void verifyClaims_success() {
-        assertThat(didJwtCredentialsVerifier.verifyClaims(JWT, SUBJECT)).isTrue();
+        assertThat(didJwtCredentialsVerifier.verifyClaims(JWT, SUBJECT).succeeded()).isTrue();
     }
 
     @Test
     void verifyClaims_OnInvalidSubject() {
-        assertThat(didJwtCredentialsVerifier.verifyClaims(JWT, OTHER_SUBJECT)).isFalse();
+        assertThat(didJwtCredentialsVerifier.verifyClaims(JWT, OTHER_SUBJECT).failed()).isTrue();
     }
 
     @Test
     void verifyClaims_OnEmptySubject() {
         var jwt = buildSignedJwt(generateVerifiableCredential(), ISSUER, null, JWK);
-        assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, OTHER_SUBJECT)).isFalse();
+        assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, OTHER_SUBJECT).failed()).isTrue();
     }
 
     @Test
     void verifyClaims_OnEmptyIssuer() {
         var jwt = buildSignedJwt(generateVerifiableCredential(), null, SUBJECT, JWK);
-        assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, SUBJECT)).isFalse();
+        assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, SUBJECT).failed()).isTrue();
     }
 
     @Test
@@ -132,7 +132,7 @@ public class DidJwtCredentialsVerifierTest {
         when(jwt.getJWTClaimsSet()).thenThrow(new ParseException(message, 0));
 
         // Act
-        assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, SUBJECT)).isFalse();
+        assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, SUBJECT).failed()).isTrue();
     }
 
     @Test
@@ -145,7 +145,7 @@ public class DidJwtCredentialsVerifierTest {
 
         SignedJWT jwt = VerifiableCredentialTestUtil.buildSignedJwt(claims, JWK);
 
-        assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, SUBJECT)).isTrue();
+        assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, SUBJECT).succeeded()).isTrue();
     }
 
     @Test
@@ -158,7 +158,7 @@ public class DidJwtCredentialsVerifierTest {
 
         SignedJWT jwt = VerifiableCredentialTestUtil.buildSignedJwt(claims, JWK);
 
-        assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, SUBJECT)).isFalse();
+        assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, SUBJECT).failed()).isTrue();
     }
 
     @Test
@@ -171,7 +171,7 @@ public class DidJwtCredentialsVerifierTest {
 
         SignedJWT jwt = VerifiableCredentialTestUtil.buildSignedJwt(claims, JWK);
 
-        assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, SUBJECT)).isTrue();
+        assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, SUBJECT).succeeded()).isTrue();
     }
 
     @Test
@@ -184,6 +184,6 @@ public class DidJwtCredentialsVerifierTest {
 
         SignedJWT jwt = VerifiableCredentialTestUtil.buildSignedJwt(claims, JWK);
 
-        assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, SUBJECT)).isFalse();
+        assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, SUBJECT).failed()).isTrue();
     }
 }

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
@@ -37,7 +37,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.buildSignedJwt;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.generateEcKey;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.generateVerifiableCredential;
-import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.toMap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -62,7 +61,7 @@ public class IdentityHubCredentialsVerifierTest {
     private CredentialsVerifier credentialsVerifier = new IdentityHubCredentialsVerifier(identityHubClientMock, monitorMock, jwtCredentialsVerifierMock, verifiableCredentialsJwtService);
 
     @Test
-    public void getVerifiedClaims_getValidClaims() throws Exception {
+    public void getVerifiedClaims_getValidClaims() {
 
         // Arrange
         var credential = generateVerifiableCredential();
@@ -73,10 +72,7 @@ public class IdentityHubCredentialsVerifierTest {
         var credentials = credentialsVerifier.getVerifiedCredentials(DID_DOCUMENT);
 
         // Assert
-        assertThat(credentials.succeeded()).isTrue();
-        assertThat(credentials.getContent())
-                .usingRecursiveComparison()
-                .isEqualTo(toMap(credential, ISSUER, SUBJECT));
+        assertThat(credentials.failed()).isTrue();
     }
 
     private void setUpMocks(SignedJWT jws, boolean isSigned, boolean claimsValid) {
@@ -86,7 +82,7 @@ public class IdentityHubCredentialsVerifierTest {
     }
 
     @Test
-    public void getVerifiedClaims_filtersSignedByWrongIssuer() throws Exception {
+    public void getVerifiedClaims_filtersSignedByWrongIssuer() {
 
         // Arrange
         var credential = generateVerifiableCredential();
@@ -97,8 +93,7 @@ public class IdentityHubCredentialsVerifierTest {
         var credentials = credentialsVerifier.getVerifiedCredentials(DID_DOCUMENT);
 
         // Assert
-        assertThat(credentials.succeeded()).isTrue();
-        assertThat(credentials.getContent().size()).isEqualTo(0);
+        assertThat(credentials.failed()).isTrue();
     }
 
     @Test
@@ -138,8 +133,7 @@ public class IdentityHubCredentialsVerifierTest {
         var credentials = credentialsVerifier.getVerifiedCredentials(DID_DOCUMENT);
 
         // Assert
-        assertThat(credentials.succeeded()).isTrue();
-        assertThat(credentials.getContent().isEmpty());
+        assertThat(credentials.failed()).isTrue();
         verify(monitorMock, times(1)).warning(anyString());
 
     }
@@ -161,8 +155,7 @@ public class IdentityHubCredentialsVerifierTest {
         var credentials = credentialsVerifier.getVerifiedCredentials(DID_DOCUMENT);
 
         // Assert
-        assertThat(credentials.succeeded()).isTrue();
-        assertThat(credentials.getContent().isEmpty());
+        assertThat(credentials.failed()).isTrue();
         verify(monitorMock, times(1)).warning(anyString());
     }
 

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
@@ -29,9 +29,11 @@ import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.buildSignedJwt;
@@ -39,7 +41,6 @@ import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.Veri
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.generateVerifiableCredential;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.toMap;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -139,8 +140,7 @@ public class IdentityHubCredentialsVerifierTest {
 
         // Assert
         assertThat(credentials.failed()).isTrue();
-        verify(monitorMock, times(1)).severe(anyString());
-
+        verify(monitorMock, times(1)).severe(ArgumentMatchers.<Supplier<String>>any());
     }
 
     @Test
@@ -161,7 +161,7 @@ public class IdentityHubCredentialsVerifierTest {
 
         // Assert
         assertThat(credentials.failed()).isTrue();
-        verify(monitorMock, times(1)).severe(anyString());
+        verify(monitorMock, times(1)).severe(ArgumentMatchers.<Supplier<String>>any());
     }
 
 }

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
@@ -99,8 +99,7 @@ public class IdentityHubCredentialsVerifierTest {
         var credentials = credentialsVerifier.getVerifiedCredentials(DID_DOCUMENT);
 
         // Assert
-        assertThat(credentials.succeeded()).isTrue();
-        assertThat(credentials.getContent().size()).isEqualTo(0);
+        assertThat(credentials.failed()).isTrue();
     }
 
     @Test

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
@@ -28,6 +28,7 @@ import org.eclipse.dataspaceconnector.identityhub.credentials.VerifiableCredenti
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
+import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -77,8 +78,8 @@ public class IdentityHubCredentialsVerifierTest {
 
     private void setUpMocks(SignedJWT jws, boolean isSigned, boolean claimsValid) {
         when(identityHubClientMock.getVerifiableCredentials(HUB_BASE_URL)).thenReturn(StatusResult.success(List.of(jws)));
-        when(jwtCredentialsVerifierMock.isSignedByIssuer(jws)).thenReturn(isSigned);
-        when(jwtCredentialsVerifierMock.verifyClaims(eq(jws), any())).thenReturn(claimsValid);
+        when(jwtCredentialsVerifierMock.isSignedByIssuer(jws)).thenReturn(isSigned ? Result.success() : Result.failure("JWT not signed"));
+        when(jwtCredentialsVerifierMock.verifyClaims(eq(jws), any())).thenReturn(claimsValid ? Result.success() : Result.failure("VC not valid"));
     }
 
     @Test

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
@@ -134,7 +134,7 @@ public class IdentityHubCredentialsVerifierTest {
 
         // Assert
         assertThat(credentials.failed()).isTrue();
-        verify(monitorMock, times(1)).warning(anyString());
+        verify(monitorMock, times(1)).severe(anyString());
 
     }
 
@@ -156,7 +156,7 @@ public class IdentityHubCredentialsVerifierTest {
 
         // Assert
         assertThat(credentials.failed()).isTrue();
-        verify(monitorMock, times(1)).warning(anyString());
+        verify(monitorMock, times(1)).severe(anyString());
     }
 
 }

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.buildSignedJwt;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.generateEcKey;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.generateVerifiableCredential;
+import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.toMap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -73,6 +74,9 @@ public class IdentityHubCredentialsVerifierTest {
 
         // Assert
         assertThat(credentials.succeeded()).isTrue();
+        assertThat(credentials.getContent())
+                .usingRecursiveComparison()
+                .isEqualTo(toMap(credential, ISSUER, SUBJECT));
     }
 
     private void setUpMocks(SignedJWT jws, boolean isSigned, boolean claimsValid) {

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
@@ -72,7 +72,7 @@ public class IdentityHubCredentialsVerifierTest {
         var credentials = credentialsVerifier.getVerifiedCredentials(DID_DOCUMENT);
 
         // Assert
-        assertThat(credentials.failed()).isTrue();
+        assertThat(credentials.succeeded()).isTrue();
     }
 
     private void setUpMocks(SignedJWT jws, boolean isSigned, boolean claimsValid) {
@@ -93,7 +93,8 @@ public class IdentityHubCredentialsVerifierTest {
         var credentials = credentialsVerifier.getVerifiedCredentials(DID_DOCUMENT);
 
         // Assert
-        assertThat(credentials.failed()).isTrue();
+        assertThat(credentials.succeeded()).isTrue();
+        assertThat(credentials.getContent().size()).isEqualTo(0);
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

IdentityHubCredentialsVerifier fails if the signature verification of at least one VerifiableCredential fail.

## Why it does that

We decided to always fail if something goes wrong with verifiable credentials, to notice potential problems easily.
In MVD, the VerfiableCredentials should always be valid.

Next steps: Adapt registry service to the new contract of the JwtCredentialsVerifier.

## Further notes

Added a test to increase the DidJwtCredentialsVerifier test coverage to 100%

Added a VerificationResult class to contain result + errors.
The long term goal is that the IdentityHubCredentialsVerifier returns an object that contains the successful result + failures, to let the client decide how to proceed with errors.

## Linked Issue(s)

https://github.com/agera-edc/IdentityHub/issues/47

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/styleguide.md) for details_)
